### PR TITLE
Problem with multi-server mfiles 

### DIFF
--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -43,9 +43,10 @@ class MFilesClient():
         self.vault = vault
         self.server = ""
         self.headers = {"X-Authentication": ""}
-        self.set_server(server)
+        # need before set_server
         self.session=requests.Session()
-
+        self.set_server(server)
+        
     def set_server(self, server):
         """Set the M-Files server API URL."""
         if server[-1] != "/":

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -101,8 +101,6 @@ class MFilesClient():
         request_url = self.server + "server/authenticationtokens"
         self.request = requests.Session()
         response = self.request.post(request_url, data=auth)
-        print(response.text)
-        print(self.request)
         auth_token = json.loads(response.text)["Value"]
         self.headers = {"X-Authentication": auth_token}
 

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -99,8 +99,8 @@ class MFilesClient():
                            "Password": self.password,
                            "VaultGuid": self.vault})
         request_url = self.server + "server/authenticationtokens"
-        session = requests.Session()
-        response = session.post(request_url, data=auth)
+        self.request = requests.Session()
+        response = self.request.post(request_url, data=auth)
         print(response.text)
         print(session.cookies)
         auth_token = json.loads(response.text)["Value"]
@@ -121,7 +121,7 @@ class MFilesClient():
         if endpoint[0] == "/":
             endpoint = endpoint[1:]
         request_url = self.server + endpoint
-        response = requests.get(request_url, headers=self.headers)
+        response = self.request.get(request_url, headers=self.headers)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response.json()
@@ -142,7 +142,7 @@ class MFilesClient():
         if endpoint[0] == "/":
             endpoint = endpoint[1:]
         request_url = self.server + endpoint
-        response = requests.put(request_url, headers=self.headers, data=data)
+        response = self.request.put(request_url, headers=self.headers, data=data)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response.json()
@@ -163,7 +163,7 @@ class MFilesClient():
         if endpoint[0] == "/":
             endpoint = endpoint[1:]
         request_url = self.server + endpoint
-        response = requests.post(request_url, headers=self.headers, data=data)
+        response = self.request.post(request_url, headers=self.headers, data=data)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response.json()
@@ -480,7 +480,7 @@ class MFilesClient():
         # pylint: disable=too-many-arguments
         request_url = "%sobjects/%s/%s/%s/files/%s/content" % \
             (self.server, object_type, object_id, object_version, file_id)
-        response = requests.get(request_url, headers=self.headers)
+        response = self.request.get(request_url, headers=self.headers)
         if response.status_code != 200:
             raise MFilesException(response.text)
         with open(local_path, mode="wb+") as file_stream:
@@ -541,7 +541,7 @@ class MFilesClient():
         """
         request_url = "%sobjects/%s/%s/latest?allVersions=true" % \
             (self.server, object_type, object_id)
-        response = requests.delete(request_url, headers=self.headers)
+        response = self.request.delete(request_url, headers=self.headers)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -44,6 +44,7 @@ class MFilesClient():
         self.server = ""
         self.headers = {"X-Authentication": ""}
         self.set_server(server)
+        self.session=requests.Session()
 
     def set_server(self, server):
         """Set the M-Files server API URL."""
@@ -99,8 +100,7 @@ class MFilesClient():
                            "Password": self.password,
                            "VaultGuid": self.vault})
         request_url = self.server + "server/authenticationtokens"
-        self.request = requests.Session()
-        response = self.request.post(request_url, data=auth)
+        response = self.session.post(request_url, data=auth)
         auth_token = json.loads(response.text)["Value"]
         self.headers = {"X-Authentication": auth_token}
 
@@ -119,7 +119,7 @@ class MFilesClient():
         if endpoint[0] == "/":
             endpoint = endpoint[1:]
         request_url = self.server + endpoint
-        response = self.request.get(request_url, headers=self.headers)
+        response = self.session.get(request_url, headers=self.headers)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response.json()
@@ -140,7 +140,7 @@ class MFilesClient():
         if endpoint[0] == "/":
             endpoint = endpoint[1:]
         request_url = self.server + endpoint
-        response = self.request.put(request_url, headers=self.headers, data=data)
+        response = self.session.put(request_url, headers=self.headers, data=data)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response.json()
@@ -161,7 +161,7 @@ class MFilesClient():
         if endpoint[0] == "/":
             endpoint = endpoint[1:]
         request_url = self.server + endpoint
-        response = self.request.post(request_url, headers=self.headers, data=data)
+        response = self.session.post(request_url, headers=self.headers, data=data)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response.json()
@@ -478,7 +478,7 @@ class MFilesClient():
         # pylint: disable=too-many-arguments
         request_url = "%sobjects/%s/%s/%s/files/%s/content" % \
             (self.server, object_type, object_id, object_version, file_id)
-        response = self.request.get(request_url, headers=self.headers)
+        response = self.session.get(request_url, headers=self.headers)
         if response.status_code != 200:
             raise MFilesException(response.text)
         with open(local_path, mode="wb+") as file_stream:
@@ -539,7 +539,7 @@ class MFilesClient():
         """
         request_url = "%sobjects/%s/%s/latest?allVersions=true" % \
             (self.server, object_type, object_id)
-        response = self.request.delete(request_url, headers=self.headers)
+        response = self.session.delete(request_url, headers=self.headers)
         if response.status_code != 200:
             raise MFilesException(response.text)
         return response

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -102,7 +102,7 @@ class MFilesClient():
         self.request = requests.Session()
         response = self.request.post(request_url, data=auth)
         print(response.text)
-        print(session.cookies)
+        print(self.request)
         auth_token = json.loads(response.text)["Value"]
         self.headers = {"X-Authentication": auth_token}
 

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -99,8 +99,10 @@ class MFilesClient():
                            "Password": self.password,
                            "VaultGuid": self.vault})
         request_url = self.server + "server/authenticationtokens"
-        response = requests.post(request_url, data=auth)
+        session = requests.Session()
+        response = session.post(request_url, data=auth)
         print(response.text)
+        print(session.cookies)
         auth_token = json.loads(response.text)["Value"]
         self.headers = {"X-Authentication": auth_token}
 

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -101,7 +101,6 @@ class MFilesClient():
         request_url = self.server + "server/authenticationtokens"
         response = requests.post(request_url, data=auth)
         print(response.text)
-        print(response.text,file=sys.stderr)
         auth_token = json.loads(response.text)["Value"]
         self.headers = {"X-Authentication": auth_token}
 

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -100,6 +100,7 @@ class MFilesClient():
                            "VaultGuid": self.vault})
         request_url = self.server + "server/authenticationtokens"
         response = requests.post(request_url, data=auth)
+        print(response)
         auth_token = json.loads(response.text)["Value"]
         self.headers = {"X-Authentication": auth_token}
 

--- a/mfiles/client.py
+++ b/mfiles/client.py
@@ -100,7 +100,8 @@ class MFilesClient():
                            "VaultGuid": self.vault})
         request_url = self.server + "server/authenticationtokens"
         response = requests.post(request_url, data=auth)
-        print(response)
+        print(response.text)
+        print(response.text,file=sys.stderr)
         auth_token = json.loads(response.text)["Value"]
         self.headers = {"X-Authentication": auth_token}
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ Documentation: https://mfiles.readthedocs.io/en/latest/
 setup(
     name='mfiles',
     packages=find_packages(),
-    version='0.5.2.fix',
+    version='0.5.3',
     license='MIT',
     description='M-Files API wrapper',
     long_description=PYPI_DESCRIPTION,

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ Documentation: https://mfiles.readthedocs.io/en/latest/
 setup(
     name='mfiles',
     packages=find_packages(),
-    version='0.5.2',
+    version='0.5.2.fix',
     license='MIT',
     description='M-Files API wrapper',
     long_description=PYPI_DESCRIPTION,
     author='Emil Hjelm',
     author_email='emil.hjelm@climeon.com',
-    url='https://github.com/afcmrp/python-mfiles',
+    url='https://github.com/barbyware/python-mfiles',
     keywords=['M-Files', 'mfiles', 'REST', 'API'],
     python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=PYPI_DESCRIPTION,
     author='Emil Hjelm',
     author_email='emil.hjelm@climeon.com',
-    url='https://github.com/barbyware/python-mfiles',
+    url='https://github.com/afcmrp/python-mfiles',
     keywords=['M-Files', 'mfiles', 'REST', 'API'],
     python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=[

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,5 +1,5 @@
 [version]
-current = "0.5.2.fix"
+current = "0.5.3"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,5 +1,5 @@
 [version]
-current = "0.5.2"
+current = "0.5.2.fix"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
HI,

In case of multi-server environment you have to use cookie based sessions instead of authentication tokens:
https://m-files.com/APIs/REST-API/Authentication/#cookie-based-sessions

The solution is easy, create a request.Session and I use this change in all request.post call